### PR TITLE
feat: implement rollup fee charge

### DIFF
--- a/bus-mapping/src/circuit_input_builder/block.rs
+++ b/bus-mapping/src/circuit_input_builder/block.rs
@@ -109,6 +109,16 @@ pub struct Block {
     pub code: HashMap<Hash, Vec<u8>>,
     /// Inputs to the SHA3 opcode
     pub sha3_inputs: Vec<Vec<u8>>,
+
+    #[cfg(feature = "kanvas")]
+    /// L1 base fee
+    pub l1_base_fee: Word,
+    #[cfg(feature = "kanvas")]
+    /// L1 fee overhead
+    pub l1_fee_overhead: Word,
+    #[cfg(feature = "kanvas")]
+    /// L1 fee scalar
+    pub l1_fee_scalar: Word,
 }
 
 impl Block {

--- a/bus-mapping/src/circuit_input_builder/execution.rs
+++ b/bus-mapping/src/circuit_input_builder/execution.rs
@@ -113,6 +113,12 @@ pub enum ExecState {
     #[cfg(feature = "kanvas")]
     /// Virtual step End Tx for Kanvas deposit tx
     EndDepositTx,
+    #[cfg(feature = "kanvas")]
+    /// Virtual step Base Fee Hook
+    BaseFeeHook,
+    #[cfg(feature = "kanvas")]
+    /// Virtual step Rollup Fee Hook
+    RollupFeeHook,
 }
 
 impl ExecState {
@@ -150,6 +156,12 @@ impl ExecState {
         } else {
             false
         }
+    }
+
+    #[cfg(feature = "kanvas")]
+    /// Returns `true` if `ExecState` is `BaseFeeHook` or `RollupFeeHook`.
+    pub fn is_fee_hook(&self) -> bool {
+        *self == ExecState::BaseFeeHook || *self == ExecState::RollupFeeHook
     }
 }
 

--- a/bus-mapping/src/circuit_input_builder/input_state_ref.rs
+++ b/bus-mapping/src/circuit_input_builder/input_state_ref.rs
@@ -99,6 +99,44 @@ impl<'a> CircuitInputStateRef<'a> {
         exec_step
     }
 
+    #[cfg(feature = "kanvas")]
+    /// Create a new BaseFeeHook step
+    pub fn new_base_fee_fee_hook_step(&self) -> ExecStep {
+        let prev_step = self
+            .tx
+            .steps()
+            .last()
+            .expect("steps should have at least one BeginTx step");
+        ExecStep {
+            exec_state: ExecState::BaseFeeHook,
+            // Dispatch to EndTx step
+            error: prev_step.error.clone(),
+            gas_left: prev_step.gas_left,
+            gas_cost: prev_step.gas_cost,
+            rwc: self.block_ctx.rwc,
+            ..Default::default()
+        }
+    }
+
+    #[cfg(feature = "kanvas")]
+    /// Create a new RollupFeeHook step
+    pub fn new_rollup_fee_hook_step(&self) -> ExecStep {
+        let prev_step = self
+            .tx
+            .steps()
+            .last()
+            .expect("steps should have at least one BeginTx step");
+        ExecStep {
+            exec_state: ExecState::RollupFeeHook,
+            // Dispatch to EndTx step
+            error: prev_step.error.clone(),
+            gas_left: prev_step.gas_left,
+            gas_cost: prev_step.gas_cost,
+            rwc: self.block_ctx.rwc,
+            ..Default::default()
+        }
+    }
+
     /// Push an [`Operation`](crate::operation::Operation) into the
     /// [`OperationContainer`](crate::operation::OperationContainer) with the
     /// next [`RWCounter`](crate::operation::RWCounter) and then adds a

--- a/bus-mapping/src/circuit_input_builder/transaction.rs
+++ b/bus-mapping/src/circuit_input_builder/transaction.rs
@@ -214,6 +214,11 @@ pub struct Transaction {
     #[cfg(feature = "kanvas")]
     /// Mint
     pub mint: Word,
+
+    /// Kanvas non-deposit tx.
+    #[cfg(feature = "kanvas")]
+    /// Rollup data gas
+    pub rollup_data_gas: u64,
 }
 
 impl From<&Transaction> for geth_types::Transaction {
@@ -236,6 +241,8 @@ impl From<&Transaction> for geth_types::Transaction {
             s: tx.signature.s,
             #[cfg(feature = "kanvas")]
             mint: tx.mint,
+            #[cfg(feature = "kanvas")]
+            rollup_data_gas: tx.rollup_data_gas,
             ..Default::default()
         }
     }
@@ -319,6 +326,8 @@ impl Transaction {
             },
             #[cfg(feature = "kanvas")]
             mint: eth_types::geth_types::Transaction::get_mint(eth_tx).unwrap_or_default(),
+            #[cfg(feature = "kanvas")]
+            rollup_data_gas: eth_types::geth_types::Transaction::compute_rollup_data_gas(eth_tx),
         })
     }
 

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -6,6 +6,18 @@ use ethers_core::utils::keccak256;
 use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
 
+#[cfg(feature = "kanvas")]
+use crate::{
+    circuit_input_builder::{Block, Transaction},
+    Error,
+};
+#[cfg(feature = "kanvas")]
+use eth_types::kanvas_params::{
+    BASE_FEE_KEY, L1_BLOCK, L1_COST_DENOMINATOR, L1_FEE_OVERHEAD_KEY, L1_FEE_SCALAR_KEY,
+};
+#[cfg(all(feature = "test", feature = "kanvas"))]
+use eth_types::kanvas_params::{BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT};
+
 lazy_static! {
     static ref ACCOUNT_ZERO: Account = Account::zero();
     static ref VALUE_ZERO: Word = Word::zero();
@@ -92,14 +104,37 @@ pub struct StateDB {
 impl StateDB {
     /// Create an empty Self
     pub fn new() -> Self {
-        Self {
+        let mut _db = Self {
             state: HashMap::new(),
             access_list_account: HashSet::new(),
             access_list_account_storage: HashSet::new(),
             dirty_storage: HashMap::new(),
             destructed_account: HashSet::new(),
             refund: 0,
-        }
+        };
+        #[cfg(all(feature = "test", feature = "kanvas"))]
+        _db.add_recipients_for_testing();
+        _db
+    }
+
+    #[cfg(all(feature = "test", feature = "kanvas"))]
+    fn add_recipients_for_testing(&mut self) {
+        self.set_account(&BASE_FEE_RECIPIENT, Account::zero());
+        self.set_account(&L1_FEE_RECIPIENT, Account::zero());
+
+        let mut storage: HashMap<Word, Word> = HashMap::new();
+        storage.insert(*BASE_FEE_KEY, Word::from(8));
+        storage.insert(*L1_FEE_OVERHEAD_KEY, Word::from(2100));
+        storage.insert(*L1_FEE_SCALAR_KEY, Word::from(1000000));
+        self.set_account(
+            &L1_BLOCK,
+            Account {
+                nonce: Word::zero(),
+                balance: Word::zero(),
+                storage,
+                code_hash: Hash::random(),
+            },
+        );
     }
 
     /// Set an [`Account`] at `addr` in the StateDB.
@@ -238,6 +273,44 @@ impl StateDB {
     /// Set refund
     pub fn set_refund(&mut self, value: u64) {
         self.refund = value;
+    }
+
+    #[cfg(feature = "kanvas")]
+    /// Compute rollup l1 fee. See core/types/rollup_l1_cost.go in kanvas-geth
+    /// for details.
+    pub fn compute_l1_fee(&self, block: &mut Block, tx: &Transaction) -> Result<Word, Error> {
+        self.do_compute_l1_fee(block, tx.rollup_data_gas)
+    }
+
+    #[cfg(feature = "kanvas")]
+    /// Compute rollup l1 fee. See core/types/rollup_l1_cost.go in kanvas-geth
+    /// for details.
+    pub fn do_compute_l1_fee(
+        &self,
+        block: &mut Block,
+        rollup_data_gas: u64,
+    ) -> Result<Word, Error> {
+        let (found, l1_base_fee) = self.get_storage(&L1_BLOCK, &BASE_FEE_KEY);
+        if !found {
+            return Err(Error::StorageKeyNotFound(*L1_BLOCK, *BASE_FEE_KEY));
+        }
+        let (found, l1_fee_overhead) = self.get_storage(&L1_BLOCK, &L1_FEE_OVERHEAD_KEY);
+        if !found {
+            return Err(Error::StorageKeyNotFound(*L1_BLOCK, *L1_FEE_OVERHEAD_KEY));
+        }
+        let (found, l1_fee_scalar) = self.get_storage(&L1_BLOCK, &L1_FEE_SCALAR_KEY);
+        if !found {
+            return Err(Error::StorageKeyNotFound(*L1_BLOCK, *L1_FEE_SCALAR_KEY));
+        }
+
+        block.l1_base_fee = l1_base_fee.clone();
+        block.l1_fee_overhead = l1_fee_overhead.clone();
+        block.l1_fee_scalar = l1_fee_scalar.clone();
+
+        Ok(
+            (Word::from(rollup_data_gas) + l1_fee_overhead) * l1_base_fee * l1_fee_scalar
+                / *L1_COST_DENOMINATOR,
+        )
     }
 
     /// Clear access list and refund, and commit dirty storage.

--- a/eth-types/src/kanvas_params.rs
+++ b/eth-types/src/kanvas_params.rs
@@ -1,0 +1,25 @@
+//! Params for Kanvas Network
+
+use ethers_core::types::Address;
+use lazy_static::lazy_static;
+
+use crate::{address, Word};
+
+lazy_static! {
+  /// The pre-deployed contract that stores the information to compute l1 rollup cost.
+  pub static ref L1_BLOCK: Address = address!("0x4200000000000000000000000000000000000015");
+  /// The pre-deployed contract that accumulates base fee.
+  pub static ref BASE_FEE_RECIPIENT: Address = address!("0x4200000000000000000000000000000000000019");
+  /// The pre-deployed contract that accumulates l1 rollup cost.
+  pub static ref L1_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001A");
+
+  /// The slot for basefee at L1Block.sol.
+  pub static ref BASE_FEE_KEY: Word = Word::from(1);
+  /// The slot for l1FeeOverhead at L1Block.sol.
+  pub static ref L1_FEE_OVERHEAD_KEY: Word = Word::from(5);
+  /// The slot or l1FeeScalar at L1Block.sol.
+  pub static ref L1_FEE_SCALAR_KEY: Word = Word::from(6);
+
+  /// The denominator used to compute l1 rollup cost.
+  pub static ref L1_COST_DENOMINATOR: Word = Word::from(1_000_000);
+}

--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -20,6 +20,8 @@ pub mod error;
 pub mod bytecode;
 pub mod evm_types;
 pub mod geth_types;
+#[cfg(feature = "kanvas")]
+pub mod kanvas_params;
 pub mod sign_types;
 
 pub use bytecode::Bytecode;

--- a/zkevm-circuits/src/evm_circuit/execution/base_fee_hook.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/base_fee_hook.rs
@@ -1,0 +1,116 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::UpdateBalanceGadget,
+            constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            math_gadget::MulWordByU64Gadget,
+            CachedRegion, Cell,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    table::{BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag},
+    util::Expr,
+};
+use eth_types::{kanvas_params::BASE_FEE_RECIPIENT, Field, ToScalar};
+use halo2_proofs::{circuit::Value, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct BaseFeeHookGadget<F> {
+    tx_id: Cell<F>,
+    tx_gas: Cell<F>,
+    mul_base_fee_by_gas_used: MulWordByU64Gadget<F>,
+    base_fee_recipient: Cell<F>,
+    base_fee_reward: UpdateBalanceGadget<F, 2, true>,
+}
+
+impl<F: Field> ExecutionGadget<F> for BaseFeeHookGadget<F> {
+    const NAME: &'static str = "BaseFeeHook";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::BaseFeeHook;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let tx_id = cb.call_context(None, CallContextFieldTag::TxId);
+        let tx_gas = cb.tx_context(tx_id.expr(), TxContextFieldTag::Gas, None);
+
+        // Add gas_used * base_fee to base_fee_recipient's balance
+        let base_fee = cb.query_word();
+        cb.block_lookup(
+            BlockContextFieldTag::BaseFee.expr(),
+            cb.curr.state.block_number.expr(),
+            base_fee.expr(),
+        );
+        let gas_used = tx_gas.expr() - cb.curr.state.gas_left.expr();
+        let mul_base_fee_by_gas_used = MulWordByU64Gadget::construct(cb, base_fee, gas_used);
+
+        let base_fee_recipient = cb.query_cell();
+        let base_fee_reward = UpdateBalanceGadget::construct(
+            cb,
+            base_fee_recipient.expr(),
+            vec![mul_base_fee_by_gas_used.product().clone()],
+            None,
+            None,
+        );
+
+        cb.require_step_state_transition(StepStateTransition {
+            rw_counter: Delta(2.expr()),
+            ..StepStateTransition::any()
+        });
+
+        Self {
+            tx_id,
+            tx_gas,
+            mul_base_fee_by_gas_used,
+            base_fee_recipient,
+            base_fee_reward,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        tx: &Transaction,
+        _: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let (base_fee_recipient_balance, base_fee_recipient_balance_prev) =
+            block.rws[step.rw_indices[1]].account_value_pair();
+
+        self.tx_id
+            .assign(region, offset, Value::known(F::from(tx.id as u64)))?;
+        self.tx_gas
+            .assign(region, offset, Value::known(F::from(tx.gas)))?;
+
+        let context = &block.context.ctxs[&tx.block_number];
+        let gas_used = tx.gas - step.gas_left;
+        let base_fee_reward = context.base_fee * gas_used;
+        self.mul_base_fee_by_gas_used.assign(
+            region,
+            offset,
+            context.base_fee,
+            gas_used,
+            base_fee_reward,
+        )?;
+        self.base_fee_recipient.assign(
+            region,
+            offset,
+            Value::known(
+                BASE_FEE_RECIPIENT
+                    .to_scalar()
+                    .expect("unexpected Address -> Scalar conversion failure"),
+            ),
+        )?;
+        self.base_fee_reward.assign(
+            region,
+            offset,
+            base_fee_recipient_balance_prev,
+            vec![base_fee_reward],
+            base_fee_recipient_balance,
+        )?;
+
+        Ok(())
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -156,6 +156,11 @@ mod test {
         // wrong `gas_left` value for the second step, to assert that
         // the circuit verification fails for this scenario.
         assert_eq!(block.txs.len(), 1);
+        #[cfg(feature = "kanvas")]
+        // BeginTx, Gas, Stop, BaseFeeHook, RollupFeeHook, EndTx, EndInnerBlock,
+        // EndBlock
+        assert_eq!(block.txs[0].steps.len(), 7);
+        #[cfg(not(feature = "kanvas"))]
         // BeginTx, Gas, Stop, EndTx, EndInnerBlock, EndBlock
         assert_eq!(block.txs[0].steps.len(), 5);
         block.txs[0].steps[2].gas_left -= 1;

--- a/zkevm-circuits/src/evm_circuit/execution/rollup_fee_hook.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/rollup_fee_hook.rs
@@ -1,0 +1,171 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        step::ExecutionState,
+        util::{
+            common_gadget::UpdateBalanceGadget,
+            constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            math_gadget::{AddWordsGadget, MulAddWordsGadget},
+            CachedRegion, Cell,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+use eth_types::{
+    kanvas_params::{L1_COST_DENOMINATOR, L1_FEE_RECIPIENT},
+    Field, ToScalar,
+};
+use halo2_proofs::{circuit::Value, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct RollupFeeHookGadget<F> {
+    add_rollup_data_gas_by_l1_fee_overhead: AddWordsGadget<F, 2, true>,
+    mul_l1_gas_to_use_by_base_fee: MulAddWordsGadget<F>,
+    mul_l1_fee_tmp_by_l1_fee_scalar: MulAddWordsGadget<F>,
+    div_l1_fee_by_l1_cost_denominator: MulAddWordsGadget<F>,
+    l1_fee_recipient: Cell<F>,
+    l1_fee_reward: UpdateBalanceGadget<F, 2, true>,
+}
+
+impl<F: Field> ExecutionGadget<F> for RollupFeeHookGadget<F> {
+    const NAME: &'static str = "RollupFeeHook";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::RollupFeeHook;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        // Add l1 rollup fee to l1_fee_recipient's balance
+        let rollup_data_gas = cb.query_word();
+        let l1_fee_overhead = cb.query_word();
+        let l1_gas_to_use = cb.query_word();
+        let add_rollup_data_gas_by_l1_fee_overhead = AddWordsGadget::construct(
+            cb,
+            [rollup_data_gas, l1_fee_overhead],
+            l1_gas_to_use.clone(),
+        );
+
+        let l1_fee_scalar = cb.query_word();
+        let zero = cb.query_word();
+        let l1_fee_tmp = cb.query_word();
+        let mul_l1_gas_to_use_by_base_fee =
+            MulAddWordsGadget::construct(cb, [&l1_gas_to_use, &l1_fee_scalar, &zero, &l1_fee_tmp]);
+        cb.require_zero(
+            "mul_l1_gas_to_use_by_base_fee's overflow == 0",
+            mul_l1_gas_to_use_by_base_fee.overflow(),
+        );
+
+        let l1_base_fee = cb.query_word();
+        let l1_fee_tmp2 = cb.query_word();
+        let mul_l1_fee_tmp_by_l1_fee_scalar =
+            MulAddWordsGadget::construct(cb, [&l1_fee_tmp, &l1_base_fee, &zero, &l1_fee_tmp2]);
+        cb.require_zero(
+            "mul_l1_fee_tmp_by_l1_fee_scalar's overflow == 0",
+            mul_l1_fee_tmp_by_l1_fee_scalar.overflow(),
+        );
+
+        let l1_fee = cb.query_word();
+        let l1_cost_denominator = cb.query_word();
+        let l1_cost_remainder = cb.query_word();
+        // TODO(chokobole): Need to check l1_cost_remainder < l1_cost_denominator
+        let div_l1_fee_by_l1_cost_denominator = MulAddWordsGadget::construct(
+            cb,
+            [
+                &l1_fee,
+                &l1_cost_denominator,
+                &l1_cost_remainder,
+                &l1_fee_tmp2,
+            ],
+        );
+        cb.require_zero(
+            "div_l1_fee_by_l1_cost_denominator's overflow == 0",
+            div_l1_fee_by_l1_cost_denominator.overflow(),
+        );
+
+        let l1_fee_recipient = cb.query_cell();
+        let l1_fee_reward =
+            UpdateBalanceGadget::construct(cb, l1_fee_recipient.expr(), vec![l1_fee], None, None);
+
+        cb.require_step_state_transition(StepStateTransition {
+            rw_counter: Delta(1.expr()),
+            ..StepStateTransition::any()
+        });
+
+        Self {
+            add_rollup_data_gas_by_l1_fee_overhead,
+            mul_l1_gas_to_use_by_base_fee,
+            mul_l1_fee_tmp_by_l1_fee_scalar,
+            div_l1_fee_by_l1_cost_denominator,
+            l1_fee_recipient,
+            l1_fee_reward,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut CachedRegion<'_, '_, F>,
+        offset: usize,
+        block: &Block<F>,
+        tx: &Transaction,
+        _: &Call,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let (l1_fee_recipient_balance, l1_fee_recipient_balance_prev) =
+            block.rws[step.rw_indices[0]].account_value_pair();
+
+        let rollup_data_gas = eth_types::Word::from(tx.rollup_data_gas);
+        let l1_gas_to_use = rollup_data_gas + block.l1_fee_overhead;
+        self.add_rollup_data_gas_by_l1_fee_overhead.assign(
+            region,
+            offset,
+            [rollup_data_gas, block.l1_fee_overhead],
+            l1_gas_to_use,
+        )?;
+        let l1_fee_tmp = l1_gas_to_use * block.l1_fee_scalar;
+        self.mul_l1_gas_to_use_by_base_fee.assign(
+            region,
+            offset,
+            [
+                l1_gas_to_use,
+                block.l1_fee_scalar,
+                eth_types::Word::zero(),
+                l1_fee_tmp,
+            ],
+        )?;
+        let l1_fee_tmp2 = l1_fee_tmp * block.l1_base_fee;
+        self.mul_l1_fee_tmp_by_l1_fee_scalar.assign(
+            region,
+            offset,
+            [
+                l1_fee_tmp,
+                block.l1_base_fee,
+                eth_types::Word::zero(),
+                l1_fee_tmp2,
+            ],
+        )?;
+        let l1_cost_denominator = *L1_COST_DENOMINATOR;
+        let (l1_fee, l1_cost_remainder) = l1_fee_tmp2.div_mod(l1_cost_denominator);
+        self.div_l1_fee_by_l1_cost_denominator.assign(
+            region,
+            offset,
+            [l1_fee, l1_cost_denominator, l1_cost_remainder, l1_fee_tmp2],
+        )?;
+        self.l1_fee_recipient.assign(
+            region,
+            offset,
+            Value::known(
+                L1_FEE_RECIPIENT
+                    .to_scalar()
+                    .expect("unexpected Address -> Scalar conversion failure"),
+            ),
+        )?;
+        self.l1_fee_reward.assign(
+            region,
+            offset,
+            l1_fee_recipient_balance_prev,
+            vec![l1_fee],
+            l1_fee_recipient_balance,
+        )?;
+
+        Ok(())
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -192,11 +192,13 @@ impl<F: Field> StopGadget<F> {
             );
         });
         cb.condition(1.expr() - is_deposit_tx.expr(), |cb| {
-            let is_to_end_tx = cb.next.execution_state_selector([ExecutionState::EndTx]);
+            let is_to_base_fee_hook = cb
+                .next
+                .execution_state_selector([ExecutionState::BaseFeeHook]);
             cb.require_equal(
-                "Go to EndTx only when is_root",
+                "Go to BaseFeeHook only when is_root",
                 cb.curr.state.is_root.expr(),
-                is_to_end_tx,
+                is_to_base_fee_hook,
             );
         });
     }

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -28,6 +28,10 @@ pub enum ExecutionState {
     EndDepositTx,
     EndInnerBlock,
     EndBlock,
+    #[cfg(feature = "kanvas")]
+    BaseFeeHook,
+    #[cfg(feature = "kanvas")]
+    RollupFeeHook,
     // Opcode successful cases
     STOP,
     ADD_SUB,     // ADD, SUB

--- a/zkevm-circuits/src/witness/block.rs
+++ b/zkevm-circuits/src/witness/block.rs
@@ -36,6 +36,17 @@ pub struct Block<F> {
     pub state_circuit_pad_to: usize,
     /// Inputs to the SHA3 opcode
     pub sha3_inputs: Vec<Vec<u8>>,
+
+    /// Kanvas
+    #[cfg(feature = "kanvas")]
+    /// L1 base fee
+    pub l1_base_fee: Word,
+    #[cfg(feature = "kanvas")]
+    /// L1 fee overhead
+    pub l1_fee_overhead: Word,
+    #[cfg(feature = "kanvas")]
+    /// L1 fee scalar
+    pub l1_fee_scalar: Word,
 }
 
 /// ...
@@ -226,6 +237,12 @@ pub fn block_convert(
             .collect(),
         copy_events: block.copy_events.clone(),
         sha3_inputs: block.sha3_inputs.clone(),
+        #[cfg(feature = "kanvas")]
+        l1_base_fee: block.l1_base_fee,
+        #[cfg(feature = "kanvas")]
+        l1_fee_overhead: block.l1_fee_overhead,
+        #[cfg(feature = "kanvas")]
+        l1_fee_scalar: block.l1_fee_scalar,
         ..Default::default()
     }
 }

--- a/zkevm-circuits/src/witness/step.rs
+++ b/zkevm-circuits/src/witness/step.rs
@@ -101,6 +101,11 @@ impl From<&ExecError> for ExecutionState {
 impl From<&circuit_input_builder::ExecStep> for ExecutionState {
     fn from(step: &circuit_input_builder::ExecStep) -> Self {
         if let Some(error) = step.error.as_ref() {
+            #[cfg(feature = "kanvas")]
+            if !step.exec_state.is_fee_hook() {
+                return error.into();
+            }
+            #[cfg(not(feature = "kanvas"))]
             return error.into();
         }
         match step.exec_state {
@@ -199,6 +204,10 @@ impl From<&circuit_input_builder::ExecStep> for ExecutionState {
             circuit_input_builder::ExecState::EndTx => ExecutionState::EndTx,
             #[cfg(feature = "kanvas")]
             circuit_input_builder::ExecState::EndDepositTx => ExecutionState::EndDepositTx,
+            #[cfg(feature = "kanvas")]
+            circuit_input_builder::ExecState::BaseFeeHook => ExecutionState::BaseFeeHook,
+            #[cfg(feature = "kanvas")]
+            circuit_input_builder::ExecState::RollupFeeHook => ExecutionState::RollupFeeHook,
         }
     }
 }

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -49,6 +49,11 @@ pub struct Transaction {
     #[cfg(feature = "kanvas")]
     /// The mint
     pub mint: Word,
+
+    /// Kanvas non-deposit tx
+    #[cfg(feature = "kanvas")]
+    /// The gas that needs to be rolled up to L1.
+    pub rollup_data_gas: u64,
 }
 
 impl Transaction {
@@ -200,6 +205,8 @@ pub(super) fn tx_convert(
         call_data_length: tx.input.len(),
         #[cfg(feature = "kanvas")]
         mint: tx.mint,
+        #[cfg(feature = "kanvas")]
+        rollup_data_gas: tx.rollup_data_gas,
         call_data_gas_cost: tx
             .input
             .iter()


### PR DESCRIPTION
- Since EIP-1559, ethereum introduces base fee and this is designed to
  be burnt. But kanvas (inherits optimism fee strategy) doesn't burn it
  and collects it to `BaseFeeVault.sol`.
- In addition to this, rollup fee that is required to batch to L1 is
  charged, too. See kanvas-geth/core/types/rollup_l1_cost.go for details.

This commit implements 2 new gadgets instead of extending EndTx Gaget.
This is because `RollupFeeGadget` consumes so much column width.