### PR TITLE
feat(zkevm-circuits): support type 126 transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,6 +3498,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "serde_json",
 ]
 
 [[package]]

--- a/bus-mapping/src/evm/opcodes/logs.rs
+++ b/bus-mapping/src/evm/opcodes/logs.rs
@@ -269,7 +269,7 @@ mod log_tests {
             .unwrap();
 
         let is_persistent = builder.block.txs()[tx_idx!(0)].calls()[0].is_persistent;
-        let callee_address = builder.block.txs()[tx_idx!(0)].to;
+        let callee_address = builder.block.txs()[tx_idx!(0)].to.unwrap_or_default();
 
         let step = builder.block.txs()[tx_idx!(0)]
             .steps()

--- a/bus-mapping/src/evm/opcodes/selfbalance.rs
+++ b/bus-mapping/src/evm/opcodes/selfbalance.rs
@@ -97,7 +97,7 @@ mod selfbalance_tests {
             .unwrap();
 
         let call_id = builder.block.txs()[tx_idx!(0)].calls()[0].call_id;
-        let callee_address = builder.block.txs()[tx_idx!(0)].to;
+        let callee_address = builder.block.txs()[tx_idx!(0)].to.unwrap_or_default();
         let self_balance = builder.sdb.get_account(&callee_address).1.balance;
 
         assert_eq!(

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -5,12 +5,15 @@ use crate::{
     AccessList, Address, Block, Bytes, Error, GethExecTrace, Hash, ToBigEndian, ToLittleEndian,
     Word, U64,
 };
-use ethers_core::types::{NameOrAddress, TransactionRequest, H256};
+use ethers_core::{
+    types::{NameOrAddress, TransactionRequest, H256},
+    utils::rlp::RlpStream,
+};
 use ethers_signers::{LocalWallet, Signer};
 use halo2_proofs::halo2curves::{group::ff::PrimeField, secp256k1};
 use num::Integer;
 use num_bigint::BigUint;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_with::serde_as;
 use sha3::{Digest, Keccak256};
 use std::{collections::HashMap, str::FromStr};
@@ -113,7 +116,7 @@ impl BlockConstants {
 }
 
 /// Definition of all of the constants related to an Ethereum transaction.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     /// Transaction type
     pub transaction_type: Option<U64>,
@@ -153,6 +156,9 @@ pub struct Transaction {
     #[cfg(feature = "kroma")]
     /// Mint
     pub mint: Word,
+    #[cfg(feature = "kroma")]
+    /// Source Hash
+    pub source_hash: H256,
 
     /// Kroma Non-deposit tx
     #[cfg(feature = "kroma")]
@@ -160,7 +166,8 @@ pub struct Transaction {
     pub rollup_data_gas_cost: u64,
 }
 
-impl From<&Transaction> for crate::Transaction {
+/// Casting `GethTransaction` to `Transaction` for response
+impl From<&Transaction> for ethers_core::types::Transaction {
     fn from(tx: &Transaction) -> crate::Transaction {
         crate::Transaction {
             transaction_type: tx.transaction_type,
@@ -183,7 +190,8 @@ impl From<&Transaction> for crate::Transaction {
     }
 }
 
-impl From<&crate::Transaction> for Transaction {
+/// Casting `Transaction` for response to `GethTransaction`
+impl From<&ethers_core::types::Transaction> for Transaction {
     fn from(tx: &crate::Transaction) -> Transaction {
         Transaction {
             transaction_type: tx.transaction_type,
@@ -204,11 +212,14 @@ impl From<&crate::Transaction> for Transaction {
             #[cfg(feature = "kroma")]
             mint: Transaction::get_mint(tx).unwrap_or_default(),
             #[cfg(feature = "kroma")]
+            source_hash: Transaction::get_source_hash(tx).unwrap_or_default(),
+            #[cfg(feature = "kroma")]
             rollup_data_gas_cost: Transaction::compute_rollup_data_gas_cost(tx),
         }
     }
 }
 
+/// Casting `GethTransaction` to `TransactionRequest`
 impl From<&Transaction> for TransactionRequest {
     fn from(tx: &Transaction) -> TransactionRequest {
         TransactionRequest {
@@ -225,16 +236,21 @@ impl From<&Transaction> for TransactionRequest {
 }
 
 impl Transaction {
-    /// Retrieve mint from `tx.other`.
-    pub fn get_mint(_tx: &crate::Transaction) -> Option<Word> {
-        #[cfg(feature = "kroma")]
-        if let Some(v) = _tx.other.get("mint") {
-            return Some(Word::from_str(v.as_str().unwrap()).unwrap());
-        }
-        None
+    /// Retrieve mint from `Transaction.other`.
+    pub fn get_mint(tx: &ethers_core::types::Transaction) -> Option<Word> {
+        tx.other
+            .get("mint")
+            .map(|v| Word::from_str(v.as_str().unwrap()).unwrap())
     }
 
-    /// Compute rollup data gas cost.
+    /// Retrieve source hash from `Transaction.other`.
+    pub fn get_source_hash(tx: &ethers_core::types::Transaction) -> Option<H256> {
+        tx.other
+            .get("sourceHash")
+            .map(|v| H256::from_str(v.as_str().unwrap()).unwrap())
+    }
+
+    /// Compute rollup data gas cost from `ResponseTransaction`
     pub fn compute_rollup_data_gas_cost(tx: &crate::Transaction) -> u64 {
         let data = tx.rlp();
         let mut zeros = 0;
@@ -250,6 +266,85 @@ impl Transaction {
         return self.transaction_type.unwrap_or_default().as_u64() == DEPOSIT_TX_TYPE;
         #[cfg(not(feature = "kroma"))]
         return false;
+    }
+
+    #[cfg(feature = "kroma")]
+    /// Return rlp encoded bytes which is used to sign tx.
+    pub fn rlp_unsigned<T: Into<U64>>(&self, chain_id: T) -> Bytes {
+        match self.transaction_type.unwrap_or_default().as_u64() {
+            0 => {
+                let mut legacy_tx = TransactionRequest::new()
+                    .from(self.from)
+                    .nonce(self.nonce)
+                    .gas_price(self.gas_price)
+                    .gas(self.gas_limit)
+                    .value(self.value)
+                    .data(self.call_data.clone())
+                    .chain_id(chain_id);
+                if self.to.is_some() {
+                    legacy_tx = legacy_tx.to(NameOrAddress::Address(self.to.unwrap()));
+                }
+
+                legacy_tx.rlp()
+            }
+            DEPOSIT_TX_TYPE => {
+                // NOTE(dongchangYoo): For deposit transactions, this function returns a byte array
+                // equivalent to the output of rlp_signed(). Even though the returned bytes are not
+                // used for transaction signing, they still need to conform to the rlp-circuit rule.
+                self.rlp_signed()
+            }
+            _ => panic!("not supported transaction type"),
+        }
+    }
+
+    #[cfg(feature = "kroma")]
+    /// Return rlp encoded bytes which is used to calculate transaction hash
+    pub fn rlp_signed(&self) -> Bytes {
+        let tx_type = self.transaction_type.unwrap_or_default().as_u64();
+        match tx_type {
+            0 => {
+                let mut legacy_tx = TransactionRequest::new()
+                    .from(self.from)
+                    .nonce(self.nonce)
+                    .gas_price(self.gas_price)
+                    .gas(self.gas_limit)
+                    .value(self.value)
+                    .data(self.call_data.clone());
+                if self.to.is_some() {
+                    legacy_tx = legacy_tx.to(NameOrAddress::Address(self.to.unwrap()));
+                }
+
+                let sig = ethers_core::types::Signature {
+                    r: self.r,
+                    s: self.s,
+                    v: self.v,
+                };
+
+                legacy_tx.rlp_signed(&sig)
+            }
+            #[cfg(feature = "kroma")]
+            DEPOSIT_TX_TYPE => {
+                let mut s = RlpStream::new();
+
+                s.append(&tx_type);
+
+                s.begin_list(7);
+                s.append(&self.source_hash);
+                s.append(&self.from);
+                if self.to.is_some() {
+                    s.append(&self.to.unwrap());
+                } else {
+                    s.append(&"");
+                }
+                s.append(&self.mint);
+                s.append(&self.value);
+                s.append(&self.gas_limit);
+                s.append(&self.call_data.to_vec());
+
+                s.out().freeze().into()
+            }
+            _ => panic!("not supported transaction type"),
+        }
     }
 
     /// Return the SignData associated with this Transaction.
@@ -356,5 +451,96 @@ impl GethData {
             // Therefore we need to update tx.hash.
             tx.hash = tx.hash();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        geth_types::Transaction,
+        sign_types::{pk_bytes_le, pk_bytes_swap_endianness, recover_pk},
+    };
+    use ethers_core::utils::keccak256;
+
+    pub const CHAIN_ID: u64 = 901;
+
+    #[test]
+    #[cfg(feature = "kroma")]
+    fn deposit_tx_rlp_test() {
+        let deposit_tx_raw = r#"{
+            "transaction_type": "0x7e",
+            "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+			"to": "0x4200000000000000000000000000000000000002",
+            "nonce": "0xa",
+            "gas_limit": "0xf4240",
+            "value": "0x0",
+            "gas_price": "0x0",
+            "gas_fee_cap": "0x0",
+            "gas_tip_cap": "0x0",
+            "call_data": "0xefc674eb00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064a66605000000000000000000000000000000000000000000000000000000003b9aca00e121af8dafefbd3429a259370c4393d3d3f9649c82e70456713396c17a8e5e67000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000007d0",
+            "access_list": [],
+            "v": 0,
+			"r": "0x0",
+			"s": "0x0",
+            "hash": "0xba940eddf4c601ec510443b19f31ca3f354f18b844cebda8ce4c43fe5d53fa70",
+            "mint": "0x0",
+            "source_hash": "0xf829b378897e49c91f6a99693364c0d290c3d5291c2784118d046ec7ddee268b",
+            "rollup_data_gas_cost": 0
+        }"#;
+
+        let deposit_tx: Transaction = serde_json::from_str(deposit_tx_raw).unwrap();
+
+        let rlp_signed = deposit_tx.rlp_signed();
+        let rlp_unsigned = deposit_tx.rlp_unsigned(CHAIN_ID);
+
+        // In case of deposit tx, it holds (dummy rlp_unsigned)
+        assert_eq!(rlp_signed, rlp_unsigned);
+
+        let tx_hash = keccak256(rlp_signed);
+        assert_eq!(
+            hex::encode(tx_hash),
+            "09d8409de0d191d50a599d21c6ddbff4cdb8b3ecde3702c0bdf5ddda50532f7a"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "kroma")]
+    fn legacy_tx_rlp_test() {
+        let legacy_tx_raw = r#"{
+            "transaction_type": "0x0",
+            "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+			"to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            "nonce": "0x0",
+            "gas_limit": "0x5208",
+            "value": "0xde0b6b3a7640000",
+            "gas_price": "0x3d7b51db",
+            "gas_fee_cap": "0x0",
+            "gas_tip_cap": "0x0",
+            "call_data": "",
+            "access_list": [],
+            "v": 1837,
+			"r": "0xec98d5757fb5c2a5622957bec95460221a12de528030aba9951323a1a7a8f7a6",
+			"s": "0x5df7b45225a4dbf0ebcbb056d6affab41f69812f2d5e5c399ec013700b2d4753",
+            "hash": "0x641c4cfd56f152d7ebd6a6a85cea8e98d1487c69a00aad606b28c6f225d06c8d",
+            "source_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "mint": "0x0",
+            "rollup_data_gas_cost": 0
+        }"#;
+
+        let kroma_tx: Transaction = serde_json::from_str(legacy_tx_raw).unwrap();
+
+        let rlp_signed = kroma_tx.rlp_signed();
+        let tx_hash = keccak256(rlp_signed);
+        assert_eq!(hex::encode(tx_hash), hex::encode(kroma_tx.hash));
+
+        let rlp_unsigned = kroma_tx.rlp_unsigned(CHAIN_ID);
+        let msg_hash = keccak256(rlp_unsigned);
+        let recover_id = ((kroma_tx.v + 1) % 2) as u8;
+
+        let pk = recover_pk(recover_id, &kroma_tx.r, &kroma_tx.s, &msg_hash).unwrap();
+        let pk_le = pk_bytes_le(&pk);
+        let pk_be = pk_bytes_swap_endianness(&pk_le);
+        let pk_hash = keccak256(pk_be);
+        assert_eq!(hex::encode(&pk_hash[12..]), hex::encode(kroma_tx.from));
     }
 }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -14,6 +14,7 @@ ethers-signers = "0.17.0"
 ethers-core = "0.17.0"
 rand_chacha = "0.3"
 rand = "0.8"
+serde_json = "1.0.66"
 
 [features]
 default = ["kroma"]

--- a/mock/src/test_ctx.rs
+++ b/mock/src/test_ctx.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 
 pub use external_tracer::LoggerConfig;
 #[cfg(feature = "kroma")]
-pub const DEPOSIT_TX_GAS: u64 = 1000000u64;
+pub const SYSTEM_DEPOSIT_TX_GAS: u64 = 1000000u64;
 #[cfg(not(feature = "kroma"))]
 pub const DEPOSIT_TX_GAS: u64 = 0u64;
 /// TestContext is a type that contains all the information from a block
@@ -333,7 +333,8 @@ pub fn gen_geth_traces(
 /// builder pattern used to construct [`TestContext`]s.
 pub mod helpers {
     use super::{eth, Bytecode, MockAccount, MockTransaction};
-    use crate::{test_ctx::DEPOSIT_TX_GAS, MOCK_ACCOUNTS};
+    use crate::{test_ctx::SYSTEM_DEPOSIT_TX_GAS, MOCK_ACCOUNTS};
+    use eth_types::H256;
     #[cfg(feature = "kroma")]
     use eth_types::{
         geth_types::DEPOSIT_TX_TYPE,
@@ -344,6 +345,7 @@ pub mod helpers {
         },
         Bytes, Word,
     };
+    use std::str::FromStr;
 
     /// Generate a simple setup which adds balance to two default accounts from
     /// [`static@MOCK_ACCOUNTS`]:
@@ -456,8 +458,15 @@ pub mod helpers {
         tx.transaction_type(DEPOSIT_TX_TYPE)
             .from(*SYSTEM_TX_CALLER)
             .to(*L1_BLOCK)
-            .gas(Word::from(DEPOSIT_TX_GAS))
+            .gas(Word::from(SYSTEM_DEPOSIT_TX_GAS))
             .gas_price(Word::zero())
+            .source_hash(
+                H256::from_str(
+                    "0x7f9da519dd53cd0705760f80addc46233ba6c3124f4566798ad1ae1fb7189307",
+                )
+                .unwrap(),
+            )
+            .mint(Word::from("0x0"))
             .input(Bytes::from(calldata));
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_sha3.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_sha3.rs
@@ -147,12 +147,12 @@ mod tests {
         eth,
         test_ctx::{
             helpers::account_0_code_account_1_no_code, SimpleTestContext, TestContext3_1,
-            DEPOSIT_TX_GAS,
+            SYSTEM_DEPOSIT_TX_GAS,
         },
         tx_idx, MOCK_ACCOUNTS,
     };
 
-    const BLOCK_GAS_LIMIT: u64 = 10_000_000_000_000_000 - DEPOSIT_TX_GAS;
+    const BLOCK_GAS_LIMIT: u64 = 10_000_000_000_000_000 - SYSTEM_DEPOSIT_TX_GAS;
 
     #[test]
     fn test_oog_sha3_less_than_constant_gas() {

--- a/zkevm-circuits/src/super_circuit.rs
+++ b/zkevm-circuits/src/super_circuit.rs
@@ -691,7 +691,7 @@ pub(crate) mod super_circuit_tests {
         SuperCircuit::<_, 1, 32, 64, 0x100>::configure(&mut cs);
         log::info!("super circuit degree: {}", cs.degree());
         log::info!("super circuit minimum_rows: {}", cs.minimum_rows());
-        assert!(cs.degree() <= 9);
+        assert!(cs.degree() <= 11);
     }
 
     fn test_super_circuit<
@@ -876,7 +876,8 @@ pub(crate) mod super_circuit_tests {
     #[test]
     fn serial_test_super_circuit_1tx_1max_tx() {
         let block = block_1tx();
-        const MAX_TXS: usize = 1;
+        const MAX_TXS: usize = tx_idx!(1);
+
         const MAX_CALLDATA: usize = 300; // sum_txs_calldata=292
         const MAX_INNER_BLOCKS: usize = 1;
         let circuits_params = CircuitsParams {
@@ -899,7 +900,7 @@ pub(crate) mod super_circuit_tests {
     #[test]
     fn serial_test_super_circuit_1tx_deploy_2max_tx() {
         let block = block_1tx_deploy();
-        const MAX_TXS: usize = 2;
+        const MAX_TXS: usize = tx_idx!(2);
         const MAX_CALLDATA: usize = 400; // sum_txs_calldata=313
         const MAX_INNER_BLOCKS: usize = 1;
         const MAX_RWS: usize = 900; // total_rws=846
@@ -924,7 +925,7 @@ pub(crate) mod super_circuit_tests {
     #[test]
     fn serial_test_super_circuit_1tx_2max_tx() {
         let block = block_1tx();
-        const MAX_TXS: usize = 2;
+        const MAX_TXS: usize = tx_idx!(2);
         const MAX_CALLDATA: usize = 300; // sum_txs_calldata=292
         const MAX_INNER_BLOCKS: usize = 1;
         let circuits_params = CircuitsParams {
@@ -947,7 +948,7 @@ pub(crate) mod super_circuit_tests {
     #[test]
     fn serial_test_super_circuit_2tx_4max_tx() {
         let block = block_2tx();
-        const MAX_TXS: usize = 4;
+        const MAX_TXS: usize = tx_idx!(4);
         const MAX_CALLDATA: usize = 300; // sum_txs_calldata=292
         const MAX_INNER_BLOCKS: usize = 1;
         const MAX_RWS: usize = 900; // total_rws=824
@@ -972,13 +973,13 @@ pub(crate) mod super_circuit_tests {
     #[test]
     fn serial_test_super_circuit_2tx_2max_tx() {
         let block = block_2tx();
-        const MAX_TXS: usize = 2;
+        const MAX_TXS: usize = tx_idx!(2);
         const MAX_CALLDATA: usize = 300; // sum_txs_calldata=292
         const MAX_INNER_BLOCKS: usize = 1;
         let circuits_params = CircuitsParams {
             max_txs: MAX_TXS,
             max_calldata: MAX_CALLDATA,
-            max_rws: 800, // total_rws=782
+            max_rws: 850, // total_rws=824
             max_copy_rows: 256,
             max_exp_steps: 256,
             max_bytecode: BYTECODE.code().len() + 100, // NOTE(TomTaehoonKim): 100 is arbitrary

--- a/zkevm-circuits/src/table.rs
+++ b/zkevm-circuits/src/table.rs
@@ -152,6 +152,9 @@ pub enum TxFieldTag {
     #[cfg(feature = "kroma")]
     /// Mint
     Mint,
+    #[cfg(feature = "kroma")]
+    /// Source hash
+    SourceHash,
     /// Kroma Non-deposit Tx
     #[cfg(feature = "kroma")]
     /// The gas cost that needs to be rolled up to L1.
@@ -1421,11 +1424,11 @@ impl CopyTable {
             };
             // is_pad
             let is_pad = Value::known(F::from(
-                is_read_step && copy_step_addr >= copy_event.src_addr_end,
+                (is_read_step && copy_step_addr >= copy_event.src_addr_end) as u64,
             ));
 
             // is_code
-            let is_code = Value::known(copy_step.is_code.map_or(F::zero(), |v| F::from(v)));
+            let is_code = Value::known(copy_step.is_code.map_or(F::zero(), |v| F::from(v as u64)));
 
             assignments.push((
                 tag,

--- a/zkevm-circuits/src/witness/rlp_encode/tx.rs
+++ b/zkevm-circuits/src/witness/rlp_encode/tx.rs
@@ -8,6 +8,7 @@ use crate::{
     util::Challenges,
     witness::{rlp_encode::common::handle_u8, tx::SignedTransaction},
 };
+use eth_types::{geth_types::DEPOSIT_TX_TYPE, ToWord};
 use ethers_core::utils::rlp;
 use halo2_proofs::{arithmetic::FieldExt, circuit::Value, plonk::Expression};
 use strum_macros::EnumIter;
@@ -27,6 +28,8 @@ pub enum RlpTxTag {
     GasPrice,
     /// Denotes the byte(s) for the tx’s gas.
     Gas,
+    /// Denotes the bytes for the tx’s from.
+    From,
     /// Denotes the bytes for the tx’s to.
     To,
     /// Denotes the byte(s) for the tx’s value.
@@ -59,6 +62,9 @@ pub enum RlpTxTag {
     /// Denotes the amount to mint for deposit tx.
     Mint,
     #[cfg(feature = "kroma")]
+    /// Denotes the bytes for tx’s source hash
+    SourceHash,
+    #[cfg(feature = "kroma")]
     /// Denotes the gas cost to roll up a tx.
     RollupDataGasCost,
 }
@@ -79,99 +85,194 @@ impl<F: FieldExt> RlpWitnessGen<F> for Transaction {
         let rlp_data = rlp::encode(self);
         let mut rows = Vec::with_capacity(rlp_data.len());
 
-        let idx = handle_prefix(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Prefix,
-            0,
-        );
-        let idx = handle_u64(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Nonce,
-            self.nonce.into(),
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::GasPrice,
-            self.gas_price,
-            idx,
-        );
-        let idx = handle_u64(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Gas,
-            self.gas.into(),
-            idx,
-        );
-        let idx = handle_address(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::To,
-            self.callee_address,
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Value,
-            self.value,
-            idx,
-        );
-        let idx = handle_bytes(
-            challenges.keccak_input(),
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::DataPrefix,
-            RlpTxTag::Data,
-            &self.call_data,
-            idx,
-        );
-        let idx = handle_u64(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::ChainId,
-            self.chain_id.into(),
-            idx,
-        );
-        let idx = handle_u8(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Zero,
-            0,
-            idx,
-        );
-        let idx = handle_u8(
-            self.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxSign,
-            RlpTxTag::Zero,
-            0,
-            idx,
-        );
+        let idx = match self.transaction_type {
+            0 => {
+                let idx = handle_prefix(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Prefix,
+                    0,
+                );
+                let idx = handle_u64(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Nonce,
+                    self.nonce.into(),
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::GasPrice,
+                    self.gas_price,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Gas,
+                    self.gas.into(),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::To,
+                    self.callee_address,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Value,
+                    self.value,
+                    idx,
+                );
+                let idx = handle_bytes(
+                    challenges.keccak_input(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::DataPrefix,
+                    RlpTxTag::Data,
+                    &self.call_data,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::ChainId,
+                    self.chain_id.into(),
+                    idx,
+                );
+                let idx = handle_u8(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Zero,
+                    0,
+                    idx,
+                );
+                let idx = handle_u8(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Zero,
+                    0,
+                    idx,
+                );
+                idx
+            }
+            #[cfg(feature = "kroma")]
+            DEPOSIT_TX_TYPE => {
+                let idx = handle_u64(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::TransactionType,
+                    self.transaction_type.into(),
+                    0,
+                );
+                let idx = handle_prefix(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Prefix,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::SourceHash,
+                    self.source_hash.to_word(),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::From,
+                    Some(self.caller_address),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::To,
+                    self.callee_address,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Mint,
+                    self.mint,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Value,
+                    self.value,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::Gas,
+                    self.gas.into(),
+                    idx,
+                );
+                let idx = handle_bytes(
+                    challenges.keccak_input(),
+                    self.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxSign,
+                    RlpTxTag::DataPrefix,
+                    RlpTxTag::Data,
+                    &self.call_data,
+                    idx,
+                );
+                idx
+            }
+            _ => panic!("not supported transaction type"),
+        };
 
         assert_eq!(
             idx,
@@ -224,101 +325,196 @@ impl<F: FieldExt> RlpWitnessGen<F> for SignedTransaction {
         let rlp_data = rlp::encode(self);
         let mut rows = Vec::with_capacity(rlp_data.len());
 
-        let idx = handle_prefix(
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::Prefix,
-            0,
-        );
-        let idx = handle_u64(
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::Nonce,
-            self.tx.nonce.into(),
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::GasPrice,
-            self.tx.gas_price,
-            idx,
-        );
-        let idx = handle_u64(
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::Gas,
-            self.tx.gas.into(),
-            idx,
-        );
-        let idx = handle_address(
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::To,
-            self.tx.callee_address,
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::Value,
-            self.tx.value,
-            idx,
-        );
-        let idx = handle_bytes(
-            challenges.keccak_input(),
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::DataPrefix,
-            RlpTxTag::Data,
-            &self.tx.call_data,
-            idx,
-        );
-        let idx = handle_u64(
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::SigV,
-            self.signature.v.into(),
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::SigR,
-            self.signature.r,
-            idx,
-        );
-        let idx = handle_u256(
-            challenges.evm_word(),
-            self.tx.id,
-            rlp_data.as_ref(),
-            &mut rows,
-            RlpDataType::TxHash,
-            RlpTxTag::SigS,
-            self.signature.s,
-            idx,
-        );
+        let idx = match self.tx.transaction_type {
+            0 => {
+                let idx = handle_prefix(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Prefix,
+                    0,
+                );
+                let idx = handle_u64(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Nonce,
+                    self.tx.nonce.into(),
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::GasPrice,
+                    self.tx.gas_price,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Gas,
+                    self.tx.gas.into(),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::To,
+                    self.tx.callee_address,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Value,
+                    self.tx.value,
+                    idx,
+                );
+                let idx = handle_bytes(
+                    challenges.keccak_input(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::DataPrefix,
+                    RlpTxTag::Data,
+                    &self.tx.call_data,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::SigV,
+                    self.signature.v.into(),
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::SigR,
+                    self.signature.r,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::SigS,
+                    self.signature.s,
+                    idx,
+                );
+                idx
+            }
+            #[cfg(feature = "kroma")]
+            DEPOSIT_TX_TYPE => {
+                let idx = handle_u64(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::TransactionType,
+                    self.tx.transaction_type.into(),
+                    0,
+                );
+                let idx = handle_prefix(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Prefix,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::SourceHash,
+                    self.tx.source_hash.to_word(),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::From,
+                    Some(self.tx.caller_address),
+                    idx,
+                );
+                let idx = handle_address(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::To,
+                    self.tx.callee_address,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Mint,
+                    self.tx.mint,
+                    idx,
+                );
+                let idx = handle_u256(
+                    challenges.evm_word(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Value,
+                    self.tx.value,
+                    idx,
+                );
+                let idx = handle_u64(
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::Gas,
+                    self.tx.gas.into(),
+                    idx,
+                );
+                let idx = handle_bytes(
+                    challenges.keccak_input(),
+                    self.tx.id,
+                    rlp_data.as_ref(),
+                    &mut rows,
+                    RlpDataType::TxHash,
+                    RlpTxTag::DataPrefix,
+                    RlpTxTag::Data,
+                    &self.tx.call_data,
+                    idx,
+                );
+                idx
+            }
+            _ => panic!("not supported transaction type"),
+        };
 
         assert_eq!(
             idx,


### PR DESCRIPTION
- add rlp encoding functions to GethTransaction. (eth-types::geth_types)
- change 'to' field of tx to optional. (in circuit_input_builder.rs)
- add source hash to tx table and every tx structs.
- fix constraints of tx_circuit and rlp circuit to support type 126 tx.
