### PR TITLE
fix(zkevm-circuits): fix bug when calculating minimum rows of rlp_circuit

### DIFF
--- a/zkevm-circuits/src/rlp_circuit.rs
+++ b/zkevm-circuits/src/rlp_circuit.rs
@@ -1894,7 +1894,7 @@ impl<F: Field> SubCircuit<F> for RlpCircuit<F, SignedTransaction> {
                 len += rlp::encode(&signed_tx).len() + 1; // 1 for DataPrefix placeholder
                 len
             })
-            .count();
+            .sum();
         (rows, std::cmp::max(1 << 18, rows))
     }
 }


### PR DESCRIPTION
* fix bug when calculating minimum rows of rlp_circuit