### PR TITLE
feat(zkevm-circuits): enable type 1 and 2 as an input data

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -357,7 +357,9 @@ impl<'a> CircuitInputBuilder {
         log::trace!("handle_tx tx {:?}", debug_tx);
         if let Some(al) = &eth_tx.access_list {
             for item in &al.0 {
-                self.sdb.add_account_to_access_list(item.address);
+                if tx.to.is_some() && tx.to.unwrap() != item.address {
+                    self.sdb.add_account_to_access_list(item.address);
+                }
                 for k in &item.storage_keys {
                     self.sdb
                         .add_account_storage_to_access_list((item.address, (*k).to_word()));

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -272,7 +272,7 @@ impl Transaction {
     /// Return rlp encoded bytes which is used to sign tx.
     pub fn rlp_unsigned<T: Into<U64>>(&self, chain_id: T) -> Bytes {
         match self.transaction_type.unwrap_or_default().as_u64() {
-            0 => {
+            0 | 1 | 2 => {
                 let mut legacy_tx = TransactionRequest::new()
                     .from(self.from)
                     .nonce(self.nonce)
@@ -302,7 +302,7 @@ impl Transaction {
     pub fn rlp_signed(&self) -> Bytes {
         let tx_type = self.transaction_type.unwrap_or_default().as_u64();
         match tx_type {
-            0 => {
+            0 | 1 | 2 => {
                 let mut legacy_tx = TransactionRequest::new()
                     .from(self.from)
                     .nonce(self.nonce)

--- a/integration-tests/src/bin/gen_blockchain_data.rs
+++ b/integration-tests/src/bin/gen_blockchain_data.rs
@@ -1,145 +1,38 @@
 use eth_types::address;
 use ethers::{
-    abi::{self, Tokenize},
-    contract::{builders::ContractCall, Contract, ContractFactory},
     core::{
-        types::{
-            transaction::eip2718::TypedTransaction, Address, TransactionReceipt,
-            TransactionRequest, U256, U64,
-        },
+        types::{TransactionRequest, U256},
         utils::WEI_IN_ETHER,
     },
     middleware::SignerMiddleware,
-    providers::{Middleware, PendingTransaction},
-    solc::Solc,
+    prelude::k256::ecdsa::SigningKey,
+    providers::{Http, Middleware, Provider},
+    signers::Wallet,
 };
 use integration_tests::{
-    get_provider, get_wallet, log_init, CompiledContract, GenDataOutput, CONTRACTS, CONTRACTS_PATH,
+    log_init,
+    scenario_utils::{
+        compile_contracts, deploy_contract, distribute_eth, init_wallets, ready_provider,
+        transfer_erc20_token, TransferContext,
+    },
+    GenDataOutput,
 };
-use log::{error, info};
-use std::{collections::HashMap, fs::File, path::Path, sync::Arc, thread::sleep, time::Duration};
-
-async fn deploy_with_result<T, M>(
-    prov: Arc<M>,
-    compiled: &CompiledContract,
-    args: T,
-) -> (Contract<M>, TransactionReceipt)
-where
-    T: Tokenize,
-    M: Middleware,
-{
-    info!("Deploying {}...", compiled.name);
-    let factory = ContractFactory::new(compiled.abi.clone(), compiled.bin.clone(), prov);
-    factory
-        .deploy(args)
-        .expect("cannot deploy")
-        .confirmations(0usize)
-        .send_with_receipt()
-        .await
-        .expect("cannot confirm deploy")
-}
-
-fn erc20_transfer<M>(
-    prov: Arc<M>,
-    contract_address: Address,
-    contract_abi: &abi::Contract,
-    to: Address,
-    amount: U256,
-) -> TypedTransaction
-where
-    M: Middleware,
-{
-    let contract = Contract::new(contract_address, contract_abi.clone(), prov);
-    let call: ContractCall<M, _> = contract
-        .method::<_, bool>("transfer", (to, amount))
-        .expect("cannot construct ERC20 transfer call");
-    // Set gas to avoid `eth_estimateGas` call
-    let call = call.legacy();
-    let call = call.gas(100_000);
-    call.tx
-}
-
-async fn send_confirm_tx<M>(prov: &Arc<M>, tx: TypedTransaction) -> TransactionReceipt
-where
-    M: Middleware,
-{
-    prov.send_transaction(tx, None)
-        .await
-        .expect("cannot send ERC20 transfer call")
-        .confirmations(0usize)
-        .await
-        .unwrap()
-        .unwrap()
-}
+use log::info;
+use std::{collections::HashMap, sync::Arc};
 
 #[tokio::main]
 async fn main() {
     log_init();
 
-    // Compile contracts
-    info!("Compiling contracts...");
-    let mut contracts = HashMap::new();
-    for (name, contract_path) in CONTRACTS {
-        let path_sol = Path::new(CONTRACTS_PATH).join(contract_path);
-        let compiled = Solc::default()
-            .compile_source(&path_sol)
-            .unwrap_or_else(|_| panic!("solc compile error {path_sol:?}"));
-        if !compiled.errors.is_empty() {
-            panic!("Errors compiling {:?}:\n{:#?}", &path_sol, compiled.errors)
-        }
+    // prepare context of scenarios
+    let contracts = compile_contracts().await;
+    let prov: Provider<Http> = ready_provider().await;
+    let wallets: Vec<Arc<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> = init_wallets();
 
-        let contract = compiled
-            .get(path_sol.to_str().expect("path is not str"), name)
-            .expect("contract not found");
-        let abi = contract.abi.expect("no abi found").clone();
-        let bin = contract.bin.expect("no bin found").clone();
-        let bin_runtime = contract.bin_runtime.expect("no bin_runtime found").clone();
-        let compiled_contract = CompiledContract {
-            path: path_sol.to_str().expect("path is not str").to_string(),
-            name: name.to_string(),
-            abi,
-            bin: bin.into_bytes().expect("bin"),
-            bin_runtime: bin_runtime.into_bytes().expect("bin_runtime"),
-        };
-
-        let mut path_json = path_sol.clone();
-        path_json.set_extension("json");
-        serde_json::to_writer(
-            &File::create(&path_json).expect("cannot create file"),
-            &compiled_contract,
-        )
-        .expect("cannot serialize json into file");
-
-        contracts.insert(name.to_string(), compiled_contract);
-    }
-    info!("Compiling contracts done...");
-
-    let prov = get_provider();
-
-    // Wait for geth to be online.
-    loop {
-        match prov.client_version().await {
-            Ok(version) => {
-                info!("Geth online: {}", version);
-                break;
-            }
-            Err(err) => {
-                error!("Geth not available: {:?}", err);
-                sleep(Duration::from_millis(500));
-            }
-        }
-    }
-
-    const NUM_TXS: usize = 4; // NUM_TXS must be >= 4 for the rest of the cases to work.
-    let wallets: Vec<_> = (0..NUM_TXS + 1)
-        .map(|i| Arc::new(SignerMiddleware::new(get_provider(), get_wallet(i as u32))))
-        .collect();
-
+    // map between case name and block_height
     let mut blocks = HashMap::new();
 
     // ETH Transfer: Transfer funds to our account.
-    //
-
     info!("Transferring funds from wallet0...");
     let tx = TransactionRequest::new()
         .to(wallets[1].address())
@@ -156,183 +49,106 @@ async fn main() {
         "Transfer 0".to_string(),
         receipt.block_number.unwrap().as_u64(),
     );
+    info!("- Done(height: {:?})", receipt.block_number);
 
     // Deploy smart contracts
-    //
-
     let mut deployments = HashMap::new();
 
-    // Greeter
-    let (contract, receipt) = deploy_with_result(
-        wallets[0].clone(),
-        contracts.get("Greeter").expect("contract not found"),
-        U256::from(42),
-    )
-    .await;
-    blocks.insert(
-        "Deploy Greeter".to_string(),
-        receipt.block_number.unwrap().as_u64(),
-    );
+    // Deploy "Greeter" contract
+    let contract_name = "Greeter";
+    let target_contract = contracts.get(contract_name).expect("contract not found");
+    let (deploy_height, contract) =
+        deploy_contract(&wallets[0], target_contract, U256::from(42)).await;
+    blocks.insert(format!("Deploy {contract_name}"), deploy_height);
     deployments.insert(
-        "Greeter".to_string(),
-        (receipt.block_number.unwrap().as_u64(), contract.address()),
+        contract_name.to_string(),
+        (deploy_height, contract.address()),
     );
 
-    // OpenZeppelinERC20TestToken
-    let (contract, receipt) = deploy_with_result(
-        wallets[0].clone(),
-        contracts
-            .get("OpenZeppelinERC20TestToken")
-            .expect("contract not found"),
-        wallets[0].address(),
-    )
-    .await;
-    blocks.insert(
-        "Deploy OpenZeppelinERC20TestToken".to_string(),
-        receipt.block_number.unwrap().as_u64(),
-    );
+    // Deploy "OpenZeppelinERC20TestToken" contract
+    let contract_name = "OpenZeppelinERC20TestToken";
+    let target_contract = contracts.get(contract_name).expect("contract not found");
+    let (deploy_height, contract) =
+        deploy_contract(&wallets[0], target_contract, wallets[0].address()).await;
+    blocks.insert(format!("Deploy {contract_name}"), deploy_height);
     deployments.insert(
-        "OpenZeppelinERC20TestToken".to_string(),
-        (receipt.block_number.unwrap().as_u64(), contract.address()),
+        contract_name.to_string(),
+        (deploy_height, contract.address()),
     );
 
     // ETH transfers: Generate a block with multiple transfers
-    //
+    let case_name = "Multiple transfers 0";
+    info!("Doing {:?}", case_name);
+    let block_num = distribute_eth(&prov, &wallets[0], &wallets).await;
+    blocks.insert(case_name.to_string(), block_num);
+    info!("- Done(height: {:?})", block_num);
 
-    info!("Generating block with multiple transfers...");
-
-    // Fund NUM_TXS wallets from wallet0
-    let mut block_num: u64;
-    loop {
-        let mut pending_txs = Vec::new();
-        let mut nonce = prov
-            .get_transaction_count(wallets[0].address(), None)
-            .await
-            .expect("cannot get transaction_count");
-        for (i, wallet) in wallets[0..NUM_TXS].iter().enumerate() {
-            info!("send transaction {}", i);
-            let tx = TransactionRequest::new()
-                .to(wallet.address())
-                .nonce(nonce)
-                .value(WEI_IN_ETHER * 2u8) // send 2 ETH
-                .from(wallets[0].address());
-            pending_txs.push(
-                wallets[0]
-                    .send_transaction(tx, None)
-                    .await
-                    .expect("cannot send tx"),
-            );
-            nonce = nonce.checked_add(U256::one()).unwrap();
-        }
-        block_num = 0;
-        let mut count = 0;
-        for (i, tx) in pending_txs.into_iter().enumerate() {
-            info!("confirm transaction {}", i);
-            let receipt = tx.await.expect("cannot confirm tx").unwrap();
-            info!("block_num: {}", receipt.block_number.unwrap().as_u64());
-            if block_num == 0 {
-                block_num = receipt.block_number.unwrap().as_u64();
-                count += 1;
-            } else if block_num == receipt.block_number.unwrap().as_u64() {
-                count += 1;
-            }
-        }
-        if count == NUM_TXS {
-            break;
-        }
-    }
-    blocks.insert("Fund wallets".to_string(), block_num);
-
-    // Make NUM_TXS transfers in a "chain"
-    loop {
-        let mut pending_txs = Vec::new();
-        let mut nonce = prov
-            .get_transaction_count(wallets[0].address(), None)
-            .await
-            .expect("cannot get transaction_count");
-        for i in 0..NUM_TXS {
-            info!("send transaction {}", i);
-            let tx = TransactionRequest::new()
-                .nonce(nonce)
-                .to(wallets[i + 1].address())
-                .value(WEI_IN_ETHER / (2 * (i + 1))) // send a fraction of an ETH
-                .from(wallets[0].address());
-            pending_txs.push(
-                wallets[0]
-                    .send_transaction(tx, None)
-                    .await
-                    .expect("cannot send tx"),
-            );
-            nonce = nonce.checked_add(U256::one()).unwrap();
-        }
-        block_num = 0;
-        let mut count = 0;
-        for (i, tx) in pending_txs.into_iter().enumerate() {
-            info!("confirm transaction {}", i);
-            let receipt = tx.await.expect("cannot confirm tx").unwrap();
-            info!("block_num: {}", receipt.block_number.unwrap().as_u64());
-            if block_num == 0 {
-                block_num = receipt.block_number.unwrap().as_u64();
-                count += 1;
-            } else if block_num == receipt.block_number.unwrap().as_u64() {
-                count += 1;
-            }
-        }
-        if count == NUM_TXS {
-            break;
-        }
-    }
-    blocks.insert("Multiple transfers 0".to_string(), block_num);
-
-    // ERC20 calls (OpenZeppelin)
-    //
-
-    info!("Generating ERC20 calls...");
-
+    // Prepare address and abi of erc20 contract
+    let contract_name = "OpenZeppelinERC20TestToken";
     let contract_address = deployments
-        .get("OpenZeppelinERC20TestToken")
+        .get(contract_name)
         .expect("contract not found")
         .1;
     let contract_abi = &contracts
-        .get("OpenZeppelinERC20TestToken")
+        .get(contract_name)
         .expect("contract not found")
         .abi;
 
     // OpenZeppelin ERC20 single failed transfer (wallet2 sends 345.67 Tokens to
     // wallet3, but wallet2 has 0 Tokens)
-    info!("Doing OpenZeppelin ERC20 single failed transfer...");
-    let amount = U256::from_dec_str("345670000000000000000").unwrap();
-    let tx = erc20_transfer(
-        wallets[2].clone(),
+    let case_name = "ERC20 OpenZeppelin transfer failed";
+    info!("Doing {:?}", case_name);
+    let exchange_map = [(2, 3, false)]
+        .iter()
+        .map(|(from_i, to_i, expected_result)| {
+            TransferContext::new(
+                *from_i,
+                *to_i,
+                U256::from_dec_str("345670000000000000000").unwrap(),
+                *expected_result,
+            )
+        })
+        .collect();
+
+    let block_num = transfer_erc20_token(
+        &prov,
         contract_address,
         contract_abi,
-        wallets[3].address(),
-        amount,
-    );
-    let receipt = send_confirm_tx(&wallets[2], tx).await;
-    assert_eq!(receipt.status, Some(U64::from(0u64)));
-    blocks.insert(
-        "ERC20 OpenZeppelin transfer failed".to_string(),
-        receipt.block_number.unwrap().as_u64(),
-    );
+        &wallets,
+        exchange_map,
+        0,
+    )
+    .await;
+    blocks.insert(case_name.to_string(), block_num);
+    info!("- Done(height: {:?})", block_num);
 
     // OpenZeppelin ERC20 single successful transfer (wallet0 sends 123.45 Tokens to
     // wallet4)
-    info!("Doing OpenZeppelin ERC20 single successful transfer...");
-    let amount = U256::from_dec_str("123450000000000000000").unwrap();
-    let tx = erc20_transfer(
-        wallets[0].clone(),
+    let case_name = "ERC20 OpenZeppelin transfer successful";
+    info!("Doing {:?}", case_name);
+    let exchange_map = [(0, 4, true)]
+        .iter()
+        .map(|(from_i, to_i, expected_result)| {
+            TransferContext::new(
+                *from_i,
+                *to_i,
+                U256::from_dec_str("123450000000000000000").unwrap(),
+                *expected_result,
+            )
+        })
+        .collect();
+
+    let block_num = transfer_erc20_token(
+        &prov,
         contract_address,
         contract_abi,
-        wallets[4].address(),
-        amount,
-    );
-    let receipt = send_confirm_tx(&wallets[0], tx).await;
-    assert_eq!(receipt.status, Some(U64::from(1u64)));
-    blocks.insert(
-        "ERC20 OpenZeppelin transfer successful".to_string(),
-        receipt.block_number.unwrap().as_u64(),
-    );
+        &wallets,
+        exchange_map,
+        0,
+    )
+    .await;
+    blocks.insert(case_name.to_string(), block_num);
+    info!("- Done(height: {:?})", block_num);
 
     // OpenZeppelin ERC20 multiple transfers in a single block (some successful,
     // some unsuccessful)
@@ -340,56 +156,33 @@ async fn main() {
     // - wallet2 -> wallet3 (ko)
     // - wallet1 -> wallet0 (ok)
     // - wallet3 -> wallet2 (ko)
-    info!("Doing OpenZeppelin ERC20 multiple transfers...");
-    loop {
-        let mut tx_hashes = Vec::new();
-        for (i, (from_i, to_i)) in [(0, 1), (2, 3), (1, 0), (3, 2)].iter().enumerate() {
-            let amount = U256::from(0x800000000000000 / (i + 1));
-            let prov_wallet = &wallets[*from_i];
-            let tx = erc20_transfer(
-                prov_wallet.clone(),
-                contract_address,
-                contract_abi,
-                wallets[*to_i].address(),
-                amount,
-            );
+    let case_name = "Multiple ERC20 OpenZeppelin transfers";
+    info!("Doing {:?}", case_name);
+    let base_amount = 0x800000000000000;
+    let exchange_map = [(0, 1, true), (2, 3, false), (1, 0, true), (3, 2, false)]
+        .iter()
+        .enumerate()
+        .map(|(i, (from_i, to_i, expected_result))| {
+            TransferContext::new(
+                *from_i,
+                *to_i,
+                U256::from(base_amount / (i + 1)),
+                *expected_result,
+            )
+        })
+        .collect();
 
-            let pending_tx = prov_wallet
-                .send_transaction(tx, None)
-                .await
-                .expect("cannot send ERC20 transfer call");
-            let tx_hash = *pending_tx; // Deref for PendingTransaction returns TxHash
-            tx_hashes.push(tx_hash);
-        }
-        block_num = 0;
-        let mut count = 0;
-        for (i, tx_hash) in tx_hashes.iter().enumerate() {
-            info!("confirm transaction {}", i);
-            let pending_tx = PendingTransaction::new(*tx_hash, wallets[i].inner());
-            let receipt = pending_tx.confirmations(0usize).await.unwrap().unwrap();
-            let expected_status = u64::from(i % 2 == 0);
-            assert_eq!(
-                receipt.status,
-                Some(U64::from(expected_status)),
-                "failed tx hash: {tx_hash:?}, receipt: {receipt:#?}"
-            );
-
-            info!("block_num: {}", receipt.block_number.unwrap().as_u64());
-            if block_num == 0 {
-                block_num = receipt.block_number.unwrap().as_u64();
-                count += 1;
-            } else if block_num == receipt.block_number.unwrap().as_u64() {
-                count += 1;
-            }
-        }
-        if count == tx_hashes.len() {
-            break;
-        }
-    }
-    blocks.insert(
-        "Multiple ERC20 OpenZeppelin transfers".to_string(),
-        block_num,
-    );
+    let block_num = transfer_erc20_token(
+        &prov,
+        contract_address,
+        contract_abi,
+        &wallets,
+        exchange_map,
+        0,
+    )
+    .await;
+    blocks.insert(case_name.to_string(), block_num);
+    info!("- Done(height: {:?})", block_num);
 
     let gen_data = GenDataOutput {
         coinbase: address!("0x0000000000000000000000000000000000000000"),

--- a/integration-tests/src/bin/gen_blockchain_data.rs
+++ b/integration-tests/src/bin/gen_blockchain_data.rs
@@ -184,6 +184,28 @@ async fn main() {
     blocks.insert(case_name.to_string(), block_num);
     info!("- Done(height: {:?})", block_num);
 
+    // OpenZeppelin ERC20 multiple type 2 transfers in a single block.
+    let case_name = "Multiple ERC20 OpenZeppelin type 2 transfers";
+    info!("Doing {:?}", case_name);
+    let transfer_map = [(0, 1, true), (1, 2, true), (2, 3, true), (3, 4, true)]
+        .iter()
+        .map(|(from_i, to_i, expected_result)| {
+            TransferContext::new(*from_i, *to_i, WEI_IN_ETHER, *expected_result)
+        })
+        .collect();
+
+    let block_num = transfer_erc20_token(
+        &prov,
+        contract_address,
+        contract_abi,
+        &wallets,
+        transfer_map,
+        2,
+    )
+    .await;
+    blocks.insert(case_name.to_string(), block_num);
+    info!("- Done(height: {:?})", block_num);
+
     let gen_data = GenDataOutput {
         coinbase: address!("0x0000000000000000000000000000000000000000"),
         wallets: wallets.iter().map(|w| w.address()).collect(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -165,3 +165,5 @@ pub struct CompiledContract {
 
 /// Common code for integration tests of circuits.
 pub mod integration_test_circuits;
+/// Common helper code for constructing scenario.
+pub mod scenario_utils;

--- a/integration-tests/src/scenario_utils.rs
+++ b/integration-tests/src/scenario_utils.rs
@@ -1,0 +1,222 @@
+use eth_types::{Address, U256};
+use ethers::{
+    abi::{self, Tokenize},
+    contract::Contract,
+    prelude::{k256::ecdsa::SigningKey, ContractFactory, SignerMiddleware},
+    providers::{Http, Middleware, PendingTransaction, Provider},
+    signers::Wallet,
+    solc::Solc,
+    types::TransactionRequest,
+    utils::WEI_IN_ETHER,
+};
+use log::{error, info};
+use std::{collections::HashMap, fs::File, path::Path, sync::Arc, thread::sleep, time::Duration};
+
+use crate::{get_provider, get_wallet, CompiledContract, CONTRACTS, CONTRACTS_PATH};
+
+/// Number of transactions in each scenario
+/// it must be >= 4 for the rest of the cases to work.
+pub const NUM_TXS: usize = 4;
+/// Wallet Type
+pub type WalletType = Arc<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
+
+/// Wait for geth to be online.
+pub async fn ready_provider() -> Provider<Http> {
+    let prov: Provider<Http> = get_provider();
+    loop {
+        match prov.client_version().await {
+            Ok(version) => {
+                info!("Geth online: {}", version);
+                break;
+            }
+            Err(err) => {
+                error!("Geth not available: {:?}", err);
+                sleep(Duration::from_millis(500));
+            }
+        }
+    }
+    prov
+}
+
+/// Init wallets to be used in each scenario
+pub fn init_wallets() -> Vec<WalletType> {
+    (0..NUM_TXS + 1)
+        .map(|i| Arc::new(SignerMiddleware::new(get_provider(), get_wallet(i as u32))))
+        .collect()
+}
+
+/// Return map of compiled contracts
+pub async fn compile_contracts() -> HashMap<String, CompiledContract> {
+    // Compile contracts
+    let mut contracts = HashMap::new();
+    for (name, contract_path) in CONTRACTS {
+        let path_sol = Path::new(CONTRACTS_PATH).join(contract_path);
+        let compiled = Solc::default()
+            .compile_source(&path_sol)
+            .unwrap_or_else(|_| panic!("solc compile error {path_sol:?}"));
+        if !compiled.errors.is_empty() {
+            panic!("Errors compiling {:?}:\n{:#?}", &path_sol, compiled.errors)
+        }
+
+        let contract = compiled
+            .get(path_sol.to_str().expect("path is not str"), name)
+            .expect("contract not found");
+        let abi = contract.abi.expect("no abi found").clone();
+        let bin = contract.bin.expect("no bin found").clone();
+        let bin_runtime = contract.bin_runtime.expect("no bin_runtime found").clone();
+        let compiled_contract = CompiledContract {
+            path: path_sol.to_str().expect("path is not str").to_string(),
+            name: name.to_string(),
+            abi,
+            bin: bin.into_bytes().expect("bin"),
+            bin_runtime: bin_runtime.into_bytes().expect("bin_runtime"),
+        };
+
+        let mut path_json = path_sol.clone();
+        path_json.set_extension("json");
+        serde_json::to_writer(
+            &File::create(&path_json).expect("cannot create file"),
+            &compiled_contract,
+        )
+        .expect("cannot serialize json into file");
+
+        contracts.insert(name.to_string(), compiled_contract);
+    }
+
+    contracts
+}
+
+/// Deploy contract
+pub async fn deploy_contract<M, T>(
+    wallet: &Arc<M>,
+    compiled: &CompiledContract,
+    args: T,
+) -> (u64, Contract<M>)
+where
+    M: Middleware,
+    T: Tokenize,
+{
+    let factory = ContractFactory::new(compiled.abi.clone(), compiled.bin.clone(), wallet.clone());
+    let (contract, receipt) = factory
+        .deploy(args)
+        .unwrap_or_else(|_| panic!("cannot construct contract creation tx: {:?}", compiled.name))
+        .confirmations(0usize)
+        .send_with_receipt()
+        .await
+        .unwrap_or_else(|_| panic!("cannot send creation tx: {:?}", compiled.name));
+
+    (receipt.block_number.unwrap().as_u64(), contract)
+}
+
+/// A `sender` account sends ETH to multiple accounts
+pub async fn distribute_eth(
+    prov: &Provider<Http>,
+    sender: &WalletType,
+    wallets: &[WalletType],
+) -> u64 {
+    // Fund NUM_TXS wallets from wallet0
+    let mut pending_txs = Vec::new();
+    let mut nonce = prov
+        .get_transaction_count(sender.address(), None)
+        .await
+        .expect("cannot get transaction_count");
+
+    for wallet in wallets[0..NUM_TXS].iter() {
+        let tx = TransactionRequest::new()
+            .to(wallet.address())
+            .nonce(nonce)
+            .value(WEI_IN_ETHER * 2u8) // send 2 ETH
+            .from(sender.address());
+        pending_txs.push(
+            wallets[0]
+                .send_transaction(tx, None)
+                .await
+                .expect("cannot send tx"),
+        );
+        nonce = nonce.checked_add(U256::one()).unwrap();
+    }
+
+    wait_pending_txs(pending_txs).await
+}
+
+/// Wait pending transactions
+pub async fn wait_pending_txs(pending_txs: Vec<PendingTransaction<'_, Http>>) -> u64 {
+    let mut block_num = 0;
+    for tx in pending_txs.into_iter() {
+        let receipt = tx.await.expect("cannot confirm tx").unwrap();
+        if block_num == 0 {
+            block_num = receipt.block_number.unwrap().as_u64();
+        } else if block_num != receipt.block_number.unwrap().as_u64() {
+            panic!("The txs are not in a block")
+        }
+    }
+    block_num
+}
+
+/// TransferContext
+pub struct TransferContext {
+    /// Index of `from` wallet
+    pub from: usize,
+    /// Index of `to` wallet
+    pub to: usize,
+    /// Amount to transfer
+    pub amount: U256,
+    /// Expected result
+    pub expected: bool,
+}
+
+impl TransferContext {
+    /// init an instance
+    pub fn new(from: usize, to: usize, amount: U256, expected: bool) -> Self {
+        Self {
+            from,
+            to,
+            amount,
+            expected,
+        }
+    }
+}
+
+/// Build and return erc20 transfer transaction
+/// TODO(dongchangYoo): this function does not support sending multiple txs from an account.
+pub async fn transfer_erc20_token(
+    prov: &Provider<Http>,
+    contract_address: Address,
+    contract_abi: &abi::Contract,
+    wallets: &[WalletType],
+    exchange_map: Vec<TransferContext>,
+    tx_type: usize,
+) -> u64 {
+    let contract = Contract::new(contract_address, contract_abi.clone(), prov.clone());
+
+    let mut pending_txs = Vec::new();
+    for trans_ctx in exchange_map.iter() {
+        let call = contract
+            .method::<_, bool>(
+                "transfer",
+                (wallets[trans_ctx.to].address(), trans_ctx.amount),
+            )
+            .expect("cannot construct ERC20 transfer call");
+
+        // Set gas to avoid `eth_estimateGas` call
+        let call = call.gas(100_000);
+
+        // Convert tx to legacy tx if tx_type equals to 0
+        // TODO(dongchangYoo): use constant for tx_type after implementing various tx types
+        let tx = if tx_type == 0 {
+            let call = call.legacy();
+            call.tx
+        } else {
+            call.tx
+        };
+
+        pending_txs.push(
+            wallets[trans_ctx.from]
+                .send_transaction(tx, None)
+                .await
+                .expect("cannot send tx"),
+        )
+    }
+
+    wait_pending_txs(pending_txs).await
+}

--- a/integration-tests/tests/circuits.rs
+++ b/integration-tests/tests/circuits.rs
@@ -97,5 +97,9 @@ unroll_tests!(
     (
         circuit_multiple_erc20_openzeppelin_transfers,
         "Multiple ERC20 OpenZeppelin transfers"
+    ),
+    (
+        circuit_multiple_erc20_openzeppelin_type_2_transfers,
+        "Multiple ERC20 OpenZeppelin type 2 transfers"
     )
 );

--- a/zkevm-circuits/src/witness/rlp_encode/tx.rs
+++ b/zkevm-circuits/src/witness/rlp_encode/tx.rs
@@ -86,7 +86,7 @@ impl<F: FieldExt> RlpWitnessGen<F> for Transaction {
         let mut rows = Vec::with_capacity(rlp_data.len());
 
         let idx = match self.transaction_type {
-            0 => {
+            0 | 1 | 2 => {
                 let idx = handle_prefix(
                     self.id,
                     rlp_data.as_ref(),
@@ -326,7 +326,7 @@ impl<F: FieldExt> RlpWitnessGen<F> for SignedTransaction {
         let mut rows = Vec::with_capacity(rlp_data.len());
 
         let idx = match self.tx.transaction_type {
-            0 => {
+            0 | 1 | 2 => {
                 let idx = handle_prefix(
                     self.tx.id,
                     rlp_data.as_ref(),

--- a/zkevm-circuits/src/witness/tx.rs
+++ b/zkevm-circuits/src/witness/tx.rs
@@ -381,7 +381,7 @@ impl Transaction {
 impl Encodable for Transaction {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self.transaction_type {
-            0 => {
+            0 | 1 | 2 => {
                 s.begin_list(9);
                 s.append(&Word::from(self.nonce));
                 s.append(&self.gas_price);
@@ -430,7 +430,7 @@ pub struct SignedTransaction {
 impl Encodable for SignedTransaction {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self.tx.transaction_type {
-            0 => {
+            0 | 1 | 2 => {
                 s.begin_list(9);
                 s.append(&Word::from(self.tx.nonce));
                 s.append(&self.tx.gas_price);


### PR DESCRIPTION
There are 2 changes as below:

feat(zkevm-circuits): enable type 1 and 2 as a input data
- fix bug on handling access list
- ensure that the address in access list and tx's 'from/to'
  are only written once to state db in circuit input builder.
  If not, `Lookup Rw` error occurs

refac(integration-test): refactoring integration test
- The content of the gendata_output file is guaranteed.
  (If txs are not in a block, it will be dead.)
- reduced the amount of reusable code.
- simplify the setup process logs.
- add test case for type 2 tx with access list
