### PR TITLE
fix(bus-mapping, eth-types): fix assigning values to tables

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -32,7 +32,7 @@ use eth_types::{
 };
 use ethers_core::{
     k256::ecdsa::SigningKey,
-    types::{Bytes, NameOrAddress, Signature, TransactionRequest},
+    types::{Bytes, Signature, TransactionRequest},
     utils::keccak256,
 };
 use ethers_providers::JsonRpcClient;
@@ -638,27 +638,7 @@ pub fn keccak_inputs_tx_circuit(
 
     let hash_datas = txs
         .iter()
-        .map(|tx| {
-            let sig = Signature {
-                r: tx.r,
-                s: tx.s,
-                v: tx.v,
-            };
-            let mut tx: TransactionRequest = tx.into();
-            if tx.to.is_some() {
-                let to = tx.to.clone().unwrap();
-                match to {
-                    NameOrAddress::Name(_) => {}
-                    NameOrAddress::Address(addr) => {
-                        // the rlp of zero addr is 0x80
-                        if addr == Address::zero() {
-                            tx.to = None;
-                        }
-                    }
-                }
-            }
-            tx.rlp_signed(&sig).to_vec()
-        })
+        .map(|tx| tx.rlp_signed().to_vec())
         .collect::<Vec<Vec<u8>>>();
     let dummy_hash_data = {
         // dummy tx is a legacy tx.

--- a/eth-types/src/geth_types.rs
+++ b/eth-types/src/geth_types.rs
@@ -371,22 +371,7 @@ impl Transaction {
                 Error::Signature(libsecp256k1::Error::InvalidSignature),
             )?
         };
-        // msg = rlp([nonce, gasPrice, gas, to, value, data, chain_id, 0, 0])
-        let mut req: TransactionRequest = self.into();
-        if req.to.is_some() {
-            let to = req.to.clone().unwrap();
-            match to {
-                NameOrAddress::Name(_) => {}
-                NameOrAddress::Address(addr) => {
-                    if addr == Address::zero() {
-                        // the rlp of zero addr is 0x80 instead of
-                        // [0x94, 0, ..., 0]
-                        req.to = None;
-                    }
-                }
-            }
-        }
-        let msg = req.chain_id(chain_id).rlp();
+        let msg = self.rlp_unsigned(chain_id);
         let msg_hash: [u8; 32] = Keccak256::digest(&msg)
             .as_slice()
             .to_vec()


### PR DESCRIPTION
resolve the issue of differing assignments of RLP encoded values between the keccak table and tx table.