### PR TITLE
build: bump up libraries

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -15,7 +15,7 @@ ethers-core = "0.17.0"
 ethers-signers = "0.17.0"
 ethers-providers = "0.17.0"
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
-poseidon-circuit = { git = "https://github.com/kroma-network/poseidon-circuit.git", rev = "693e985" }
+poseidon-circuit = { git = "https://github.com/kroma-network/poseidon-circuit.git", rev = "b83e3db" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -29,8 +29,8 @@ keccak256 = { path = "../keccak256"}
 log = "0.4"
 env_logger = "0.9"
 
-halo2_base = { git = "https://github.com/kroma-network/halo2-lib", rev = "31e0c62", default-features = false }
-halo2_ecc = { git = "https://github.com/kroma-network/halo2-lib", rev = "31e0c62", default-features = false }
+halo2_base = { git = "https://github.com/kroma-network/halo2-lib", rev = "bf99e3e", default-features = false }
+halo2_ecc = { git = "https://github.com/kroma-network/halo2-lib", rev = "bf99e3e", default-features = false }
 
 maingate = { git = "https://github.com/kroma-network/halo2wrong", rev = "467c015" }
 
@@ -57,7 +57,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.78"
 
 [features]
-default = ["test", "test-circuits", "onephase", "enable-sign-verify","kroma"]
+default = ["test", "test-circuits", "onephase", "enable-sign-verify", "kroma"]
 test = ["ethers-signers", "mock"]
 test-circuits = []
 warn-unimplemented = ["eth-types/warn-unimplemented"]

--- a/zktrie/Cargo.toml
+++ b/zktrie/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2023_02_02" }
 mpt-circuits = { package = "halo2-mpt-circuits", git = "https://github.com/kroma-network/mpt-circuit.git", rev = "2a5e9e5" }
-zktrie = { git = "https://github.com/kroma-network/zktrie.git", rev = "b0f3ee9" }
+zktrie = { git = "https://github.com/kroma-network/zktrie.git", rev = "d33be94" }
 bus-mapping = { path = "../bus-mapping" }
 eth-types = { path = "../eth-types" }
 lazy_static = "1.4"


### PR DESCRIPTION
In this PR, the versions of `halo2-lib`, `zktrie` and `poseidon-circuit`  have been adjusted.