### PR TITLE
feat: add version constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
  "ethers-signers",
  "fp-evm",
  "gadgets",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "itertools",
  "keccak256",
@@ -528,7 +528,7 @@ dependencies = [
  "pallet-evm-precompile-curve25519",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-simple",
- "poseidon-circuit 0.1.0 (git+https://github.com/kroma-network/poseidon-circuit.git?rev=693e985)",
+ "poseidon-circuit",
  "pretty_assertions",
  "primitive-types 0.12.1",
  "rand 0.8.5",
@@ -677,7 +677,7 @@ dependencies = [
  "eth-types",
  "ethers",
  "ethers-signers",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "itertools",
  "keccak256",
  "log",
@@ -1508,7 +1508,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecc"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2wrong?rev=467c015#467c0154af1b724b163c11c13c40aa908df87ddd"
+source = "git+https://github.com/kroma-network/halo2wrong?rev=e8b55cd#e8b55cd7a448cc04d8dfcf3557e6cd73dd91436f"
 dependencies = [
  "group 0.12.1",
  "integer",
@@ -1717,14 +1717,14 @@ version = "0.1.0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "itertools",
  "lazy_static",
  "libsecp256k1",
  "num",
  "num-bigint",
- "poseidon-circuit 0.1.0 (git+https://github.com/kroma-network/poseidon-circuit.git?rev=b83e3db)",
+ "poseidon-circuit",
  "regex",
  "serde",
  "serde_json",
@@ -2534,7 +2534,7 @@ version = "0.1.0"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "rand 0.8.5",
  "rand_xorshift",
  "sha3 0.7.3",
@@ -2694,14 +2694,14 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 [[package]]
 name = "halo2-mpt-circuits"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/mpt-circuit.git?rev=2a5e9e5#2a5e9e57ece81b660ba806c8f518e976c0e471fc"
+source = "git+https://github.com/kroma-network/mpt-circuit.git?rev=0799a4a#0799a4afd5f8a35322c146e3da925d5ec91aaccc"
 dependencies = [
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "lazy_static",
  "log",
  "num-bigint",
- "poseidon-circuit 0.1.0 (git+https://github.com/kroma-network/poseidon-circuit.git?rev=b83e3db)",
+ "poseidon-circuit",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2711,10 +2711,10 @@ dependencies = [
 [[package]]
 name = "halo2_base"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2-lib?rev=31e0c62#31e0c6293789e0b1acef158ec260f968e2057416"
+source = "git+https://github.com/kroma-network/halo2-lib?rev=0027b54#0027b544ce4cd905a17ceee431f3f82bddb103fc"
 dependencies = [
  "ff 0.12.1",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2723,13 +2723,13 @@ dependencies = [
 [[package]]
 name = "halo2_ecc"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2-lib?rev=31e0c62#31e0c6293789e0b1acef158ec260f968e2057416"
+source = "git+https://github.com/kroma-network/halo2-lib?rev=0027b54#0027b544ce4cd905a17ceee431f3f82bddb103fc"
 dependencies = [
  "ark-std",
  "ff 0.12.1",
  "group 0.12.1",
  "halo2_base",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "halo2curves",
  "num-bigint",
  "num-integer",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/kroma-network/halo2.git?rev=0918c29#0918c29ed04096929ef2d006454b8eea6296d21f"
+source = "git+https://github.com/kroma-network/halo2.git?branch=halo2-with-tachyon#e98c8625d4e8a3f77c447fbe7f8dfa8687bf8047"
 dependencies = [
  "ark-std",
  "blake2b_simd",
@@ -2771,28 +2771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2_proofs"
-version = "0.2.0"
-source = "git+https://github.com/kroma-network/halo2.git?rev=9922fbb#9922fbb853201d8ad9feb82bd830a031d7c290b1"
-dependencies = [
- "ark-std",
- "blake2b_simd",
- "cfg-if 0.1.10",
- "ff 0.12.1",
- "group 0.12.1",
- "halo2curves",
- "log",
- "num-bigint",
- "num-integer",
- "poseidon",
- "rand_core 0.6.4",
- "rayon",
- "sha3 0.9.1",
- "subtle",
- "tracing",
-]
-
-[[package]]
 name = "halo2curves"
 version = "0.3.1"
 source = "git+https://github.com/kroma-network/halo2curves.git?rev=c0ac193#c0ac1935e5da2a620204b5b011be2c924b1e0155"
@@ -2814,10 +2792,10 @@ dependencies = [
 [[package]]
 name = "halo2wrong"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2wrong?rev=467c015#467c0154af1b724b163c11c13c40aa908df87ddd"
+source = "git+https://github.com/kroma-network/halo2wrong?rev=e8b55cd#e8b55cd7a448cc04d8dfcf3557e6cd73dd91436f"
 dependencies = [
  "group 0.12.1",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3174,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "integer"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2wrong?rev=467c015#467c0154af1b724b163c11c13c40aa908df87ddd"
+source = "git+https://github.com/kroma-network/halo2wrong?rev=e8b55cd#e8b55cd7a448cc04d8dfcf3557e6cd73dd91436f"
 dependencies = [
  "group 0.12.1",
  "maingate",
@@ -3202,7 +3180,7 @@ dependencies = [
  "env_logger",
  "eth-types",
  "ethers",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "lazy_static",
  "log",
@@ -3320,7 +3298,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "eth-types",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "itertools",
  "lazy_static",
  "log",
@@ -3511,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "maingate"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/halo2wrong?rev=467c015#467c0154af1b724b163c11c13c40aa908df87ddd"
+source = "git+https://github.com/kroma-network/halo2wrong?rev=e8b55cd#e8b55cd7a448cc04d8dfcf3557e6cd73dd91436f"
 dependencies = [
  "group 0.12.1",
  "halo2wrong",
@@ -3666,7 +3644,7 @@ dependencies = [
  "env_logger",
  "eth-types",
  "halo2-mpt-circuits",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "lazy_static",
  "log",
@@ -4330,21 +4308,10 @@ dependencies = [
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/poseidon-circuit.git?rev=693e985#693e985a48029d89dab84af37445179b5bbd88d2"
+source = "git+https://github.com/kroma-network/poseidon-circuit.git?rev=3d46015#3d460153b6d74e70aab86fcff1f685f6e15a2ab9"
 dependencies = [
  "bitvec 1.0.1",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=9922fbb)",
- "lazy_static",
- "thiserror",
-]
-
-[[package]]
-name = "poseidon-circuit"
-version = "0.1.0"
-source = "git+https://github.com/kroma-network/poseidon-circuit.git?rev=b83e3db#b83e3db57ff7b092d0c63e9c64596fbc09e5415f"
-dependencies = [
- "bitvec 1.0.1",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "lazy_static",
  "thiserror",
 ]
@@ -5439,10 +5406,10 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/snark-verifier?rev=1e41320#1e41320a4b1f61a773ac6594b9c1f890de5865a3"
+source = "git+https://github.com/kroma-network/snark-verifier?rev=f6251ca#f6251caba1ccdce96a5e51cdc963e24058ce0a82"
 dependencies = [
  "ecc",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "halo2curves",
  "hex",
  "itertools",
@@ -6118,7 +6085,7 @@ dependencies = [
  "ethers-signers",
  "external-tracer",
  "glob",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "handlebars",
  "hex",
  "keccak256",
@@ -7290,7 +7257,7 @@ dependencies = [
  "gadgets",
  "halo2_base",
  "halo2_ecc",
- "halo2_proofs 0.2.0 (git+https://github.com/kroma-network/halo2.git?rev=0918c29)",
+ "halo2_proofs",
  "hex",
  "itertools",
  "keccak256",
@@ -7320,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.1.2"
-source = "git+https://github.com/kroma-network/zktrie.git?rev=b0f3ee9#b0f3ee937287a115ea44f0c188df27e4cd29dfa0"
+source = "git+https://github.com/kroma-network/zktrie.git?rev=6ddaf0c#6ddaf0cc0481ea96522d31bdf8a413d6f5c93152"
 dependencies = [
  "gobuild",
 ]

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -18,6 +18,7 @@
 #![deny(unsafe_code)]
 #![deny(clippy::debug_assert_with_mut_call)]
 
+pub mod version;
 pub mod bytecode_circuit;
 pub mod copy_circuit;
 pub mod evm_circuit;

--- a/zkevm-circuits/src/version.rs
+++ b/zkevm-circuits/src/version.rs
@@ -1,0 +1,28 @@
+/// Version
+pub mod version {
+    /// Major version
+    pub const MAJOR: u32 = 0;
+    /// Minor version
+    pub const MINOR: u32 = 1;
+    /// Patch version
+    pub const PATCH: u32 = 0;
+
+    /// Export versions as string
+    pub fn as_string() -> String {
+        format!("{}.{}.{}", MAJOR, MINOR, PATCH)
+    }
+}
+
+mod tests {
+    use crate::version::version;
+
+    #[test]
+    fn test_version_string() {
+        let expected = "0.1.0";
+
+        assert_eq!(version::MAJOR, 0, "wrong version");
+        assert_eq!(version::MINOR, 1, "wrong version");
+        assert_eq!(version::PATCH, 0, "wrong version");
+        assert_eq!(version::as_string(), expected, "wrong version");
+    }
+}


### PR DESCRIPTION
In this PR, version constant variables were added. This is used in a program that uses `zkevm-circuits` to check its version.