### PR TITLE
fix(zkevm-circuits): resolve warning and error for version.rs

### DIFF
--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -18,7 +18,6 @@
 #![deny(unsafe_code)]
 #![deny(clippy::debug_assert_with_mut_call)]
 
-pub mod version;
 pub mod bytecode_circuit;
 pub mod copy_circuit;
 pub mod evm_circuit;
@@ -32,6 +31,7 @@ pub mod root_circuit;
 pub mod state_circuit;
 pub mod super_circuit;
 pub mod table;
+pub mod version;
 
 #[cfg(any(feature = "test", test))]
 pub mod test_util;

--- a/zkevm-circuits/src/version.rs
+++ b/zkevm-circuits/src/version.rs
@@ -1,20 +1,20 @@
-/// Version
-pub mod version {
-    /// Major version
-    pub const MAJOR: u32 = 0;
-    /// Minor version
-    pub const MINOR: u32 = 1;
-    /// Patch version
-    pub const PATCH: u32 = 0;
+//! Version variables and its utils
 
-    /// Export versions as string
-    pub fn as_string() -> String {
-        format!("{}.{}.{}", MAJOR, MINOR, PATCH)
-    }
+/// Major version
+pub const MAJOR: u32 = 0;
+/// Minor version
+pub const MINOR: u32 = 1;
+/// Patch version
+pub const PATCH: u32 = 0;
+
+/// Export versions as string
+pub fn as_string() -> String {
+    format!("{}.{}.{}", MAJOR, MINOR, PATCH)
 }
 
+#[cfg(test)]
 mod tests {
-    use crate::version::version;
+    use crate::version;
 
     #[test]
     fn test_version_string() {


### PR DESCRIPTION
In this PR, resolved the documentation error for the `zkevm-circuits::version` mod.